### PR TITLE
Always run HTTP request code on Context.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Under the hood, it's gonna attach the following:
 
 ```java
 return builder
-        .httpClient(new VertxNioAsyncHttpClient(context.owner())) // uses Vert.x's HttpClient to make call to AWS services
+        .httpClient(new VertxNioAsyncHttpClient(context)) // uses Vert.x's HttpClient to make call to AWS services
         .asyncConfiguration(conf -> // tells AWS to execute response callbacks in a Vert.x context
                 conf.advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, new VertxExecutor(context))
         );

--- a/src/main/java/io/reactiverse/awssdk/VertxNioAsyncHttpClient.java
+++ b/src/main/java/io/reactiverse/awssdk/VertxNioAsyncHttpClient.java
@@ -2,6 +2,7 @@ package io.reactiverse.awssdk;
 
 import io.reactiverse.awssdk.converters.MethodConverter;
 import io.reactiverse.awssdk.reactivestreams.ReadStreamPublisher;
+import io.vertx.core.Context;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
 import io.vertx.core.http.HttpClientOptions;
@@ -23,19 +24,28 @@ public class VertxNioAsyncHttpClient implements SdkAsyncHttpClient {
 
     private final Logger LOG = LoggerFactory.getLogger(VertxNioAsyncHttpClient.class);
 
-    private final Vertx vertx;
+    private final Context context;
 
-    public VertxNioAsyncHttpClient(Vertx vertx) {
-        this.vertx = vertx;
+    public VertxNioAsyncHttpClient(Context context) {
+        this.context = context;
     }
 
     @Override
     public CompletableFuture<Void> execute(AsyncExecuteRequest asyncExecuteRequest) {
+        final CompletableFuture<Void> fut = new CompletableFuture<>();
+        if (Context.isOnEventLoopThread()) {
+            executeOnContext(asyncExecuteRequest, fut);
+        } else {
+            context.runOnContext(v -> executeOnContext(asyncExecuteRequest, fut));
+        }
+        return fut;
+    }
+
+    private void executeOnContext(AsyncExecuteRequest asyncExecuteRequest, CompletableFuture<Void> fut) {
         final SdkHttpRequest request = asyncExecuteRequest.request();
         final SdkAsyncHttpResponseHandler responseHandler = asyncExecuteRequest.responseHandler();
-        final HttpClient client = vertx.createHttpClient(getClientOptions(request));
+        final HttpClient client = context.owner().createHttpClient(getClientOptions(request));
         final String fullPath = request.protocol() + "://" + request.host() + ":" + request.port() + request.encodedPath();
-        final CompletableFuture<Void> fut = new CompletableFuture<>();
 
         final HttpClientRequest vRequest = client.request(MethodConverter.awsToVertx(request.method()), fullPath).setFollowRedirects(true);
         request.headers().forEach((headerName, headerValues) -> {
@@ -61,7 +71,6 @@ public class VertxNioAsyncHttpClient implements SdkAsyncHttpClient {
         } else {
             vRequest.end();
         }
-        return fut;
     }
 
     private HttpClientOptions getClientOptions(SdkHttpRequest request) {

--- a/src/main/java/io/reactiverse/awssdk/VertxNioAsyncHttpClient.java
+++ b/src/main/java/io/reactiverse/awssdk/VertxNioAsyncHttpClient.java
@@ -36,7 +36,7 @@ public class VertxNioAsyncHttpClient implements SdkAsyncHttpClient {
         return fut;
     }
 
-    private void executeOnContext(AsyncExecuteRequest asyncExecuteRequest, CompletableFuture<Void> fut) {
+    void executeOnContext(AsyncExecuteRequest asyncExecuteRequest, CompletableFuture<Void> fut) {
         final SdkHttpRequest request = asyncExecuteRequest.request();
         final SdkAsyncHttpResponseHandler responseHandler = asyncExecuteRequest.responseHandler();
         final HttpClient client = context.owner().createHttpClient(getClientOptions(request));

--- a/src/main/java/io/reactiverse/awssdk/VertxSdkClient.java
+++ b/src/main/java/io/reactiverse/awssdk/VertxSdkClient.java
@@ -9,7 +9,7 @@ public interface VertxSdkClient {
 
     static<C extends SdkClient, B extends AwsAsyncClientBuilder<B, C>> B withVertx(B builder, Context context) {
         return builder
-                .httpClient(new VertxNioAsyncHttpClient(context.owner()))
+                .httpClient(new VertxNioAsyncHttpClient(context))
                 .asyncConfiguration(conf ->
                         conf.advancedOption(SdkAdvancedAsyncClientOption.FUTURE_COMPLETION_EXECUTOR, new VertxExecutor(context))
                 );

--- a/src/test/java/io/reactiverse/awssdk/AsyncHttpClientTest.java
+++ b/src/test/java/io/reactiverse/awssdk/AsyncHttpClientTest.java
@@ -44,7 +44,7 @@ public class AsyncHttpClientTest {
   public void setUp() {
     vertx = Vertx.vertx();
     server = vertx.createHttpServer();
-    client = new VertxNioAsyncHttpClient(vertx);
+    client = new VertxNioAsyncHttpClient(vertx.getOrCreateContext());
   }
 
   @AfterEach

--- a/src/test/java/io/reactiverse/awssdk/ContextAssertVertxNioAsyncHttpClient.java
+++ b/src/test/java/io/reactiverse/awssdk/ContextAssertVertxNioAsyncHttpClient.java
@@ -1,0 +1,27 @@
+package io.reactiverse.awssdk;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import software.amazon.awssdk.http.async.AsyncExecuteRequest;
+
+import java.util.concurrent.CompletableFuture;
+
+public class ContextAssertVertxNioAsyncHttpClient extends VertxNioAsyncHttpClient {
+
+    private Vertx vertx;
+    private Context creationContext;
+
+    public ContextAssertVertxNioAsyncHttpClient(Vertx vertx, Context context) {
+        super(context);
+        this.vertx = vertx;
+        this.creationContext = context;
+    }
+
+    @Override
+    void executeOnContext(AsyncExecuteRequest asyncExecuteRequest, CompletableFuture<Void> fut) {
+        if (vertx.getOrCreateContext() != this.creationContext) {
+            throw new AssertionError("Context should ALWAYS be the same");
+        }
+        super.executeOnContext(asyncExecuteRequest, fut);
+    }
+}

--- a/src/test/java/io/reactiverse/awssdk/RetryContextTest.java
+++ b/src/test/java/io/reactiverse/awssdk/RetryContextTest.java
@@ -1,0 +1,96 @@
+package io.reactiverse.awssdk;
+
+import io.vertx.core.Context;
+import io.vertx.core.Vertx;
+import io.vertx.core.http.HttpServerOptions;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.lambda.LambdaAsyncClient;
+import software.amazon.awssdk.services.lambda.LambdaAsyncClientBuilder;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+
+@ExtendWith(VertxExtension.class)
+class RetryContextTest {
+
+    private static final int PORT = 9876;
+    private static final String HOST = "localhost";
+    private static final HttpServerOptions SERVER_OPTS = new HttpServerOptions()
+            .setHost(HOST)
+            .setPort(PORT);
+
+    private static final AwsCredentialsProvider credentialsProvider = () -> new AwsCredentials() {
+        @Override
+        public String accessKeyId() {
+            return "a";
+        }
+
+        @Override
+        public String secretAccessKey() {
+            return "a";
+        }
+    };
+
+    private int attempts = 0;
+
+    @BeforeEach
+    @Timeout(value = 5, timeUnit = TimeUnit.SECONDS)
+    void setupFailServer(Vertx vertx, VertxTestContext ctx) {
+        attempts = 0;
+        vertx.createHttpServer(SERVER_OPTS)
+                .requestHandler(req -> {
+                    attempts++;
+                    if (attempts == 1) { // only fail for first attempt, forcing a retry
+                        req.response().setStatusCode(500).end();
+                    } else {
+                        req.response().setStatusCode(200).end(new JsonObject().encode());
+                    }
+
+                })
+                .listen(ctx.completing());
+    }
+
+    @Test
+    @Timeout(value = 20, timeUnit = TimeUnit.SECONDS)
+    void testRetry(Vertx vertx, VertxTestContext ctx) throws Exception {
+        Context originalContext = vertx.getOrCreateContext();
+        createLambdaClient(vertx, originalContext)
+                .getFunction(gfb -> gfb.functionName("dummy"))
+                .whenComplete((resp, error) -> {
+                    if (error != null) {
+                        ctx.failNow(error);
+                    } else {
+                        ctx.verify(() -> {
+                            assertSame(originalContext, vertx.getOrCreateContext());
+                            ctx.completeNow();
+                        });
+
+                    }
+                });
+    }
+
+    LambdaAsyncClient createLambdaClient(Vertx vertx, Context ctx) throws Exception {
+        final URI lambdaURI = new URI("http://" + HOST + ":" + PORT);
+        final LambdaAsyncClientBuilder builder =
+                LambdaAsyncClient.builder()
+                        .credentialsProvider(credentialsProvider)
+                        .region(Region.EU_WEST_1)
+                        .endpointOverride(lambdaURI);
+        return VertxSdkClient
+                .withVertx(builder, ctx)
+                .httpClient(new ContextAssertVertxNioAsyncHttpClient(vertx, ctx)) // override on purpose, we look forward to assert that the context is always the same
+                .build();
+    }
+}


### PR DESCRIPTION
AWS SDK would call execute() on internal thread pool for retry attempts.

This issue is similar to #2.